### PR TITLE
Update Tanka.GraphQL to 3.6.0

### DIFF
--- a/src/Chat.Api/Chat.Api.csproj
+++ b/src/Chat.Api/Chat.Api.csproj
@@ -20,10 +20,10 @@
         <PackageReference Include="System.Interactive.Async" Version="6.0.3" />
         <PackageReference Include="System.Linq.Async" Version="6.0.3" />
         <PackageReference Include="System.Reactive.Async" Version="6.0.0-alpha.18" />
-        <PackageReference Include="Tanka.GraphQL" Version="3.5.0" />
-        <PackageReference Include="Tanka.GraphQL.Language" Version="3.5.0" />
-        <PackageReference Include="Tanka.GraphQL.Server" Version="3.5.0" />
-        <PackageReference Include="Tanka.GraphQL.Server.SourceGenerators" Version="3.5.0" PrivateAssets="all" />
+        <PackageReference Include="Tanka.GraphQL" Version="3.6.0" />
+        <PackageReference Include="Tanka.GraphQL.Language" Version="3.6.0" />
+        <PackageReference Include="Tanka.GraphQL.Server" Version="3.6.0" />
+        <PackageReference Include="Tanka.GraphQL.Server.SourceGenerators" Version="3.6.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.8" />
 
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.8" />

--- a/src/Chat.Api/Chat.Api.csproj
+++ b/src/Chat.Api/Chat.Api.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ViteAppDir>UI2</ViteAppDir>
+        <TankaVersion>3.6.0</TankaVersion>
     </PropertyGroup>
     
     <ItemGroup>
@@ -20,10 +21,10 @@
         <PackageReference Include="System.Interactive.Async" Version="6.0.3" />
         <PackageReference Include="System.Linq.Async" Version="6.0.3" />
         <PackageReference Include="System.Reactive.Async" Version="6.0.0-alpha.18" />
-        <PackageReference Include="Tanka.GraphQL" Version="3.6.0" />
-        <PackageReference Include="Tanka.GraphQL.Language" Version="3.6.0" />
-        <PackageReference Include="Tanka.GraphQL.Server" Version="3.6.0" />
-        <PackageReference Include="Tanka.GraphQL.Server.SourceGenerators" Version="3.6.0" PrivateAssets="all" />
+        <PackageReference Include="Tanka.GraphQL" Version="$(TankaVersion)" />
+        <PackageReference Include="Tanka.GraphQL.Language" Version="$(TankaVersion)" />
+        <PackageReference Include="Tanka.GraphQL.Server" Version="$(TankaVersion)" />
+        <PackageReference Include="Tanka.GraphQL.Server.SourceGenerators" Version="$(TankaVersion)" PrivateAssets="all" />
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.8" />
 
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.8" />


### PR DESCRIPTION
## Summary

Update all Tanka.GraphQL packages from 3.5.0 to 3.6.0.

### Changes
- Updated Tanka.GraphQL from 3.5.0 to 3.6.0
- Updated Tanka.GraphQL.Language from 3.5.0 to 3.6.0  
- Updated Tanka.GraphQL.Server from 3.5.0 to 3.6.0
- Updated Tanka.GraphQL.Server.SourceGenerators from 3.5.0 to 3.6.0

### Testing
- ✅ Project builds successfully
- ✅ No new compilation errors
- ✅ All existing warnings remain the same (nullable reference warnings from generated code)

🤖 Generated with [Claude Code](https://claude.ai/code)